### PR TITLE
Improve interface, add testing for `OcflFilesystemRepositoryClient`

### DIFF
--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Deposit.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Deposit.java
@@ -75,7 +75,7 @@ public class Deposit implements Command {
 
     public void execute() {
         repositoryClient.createObject(
-            packageIdentifier, sourcePackage.getRootPath(), curator, message
+            packageIdentifier, sourcePackage, curator, message
         );
 
         var infoPackage = infoPackageService.createInfoPackage(packageIdentifier);

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Deposit.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Deposit.java
@@ -22,6 +22,7 @@ public class Deposit implements Command {
 
     Repository repository;
     RepositoryClient repositoryClient;
+    Package sourcePackage;
 
     public Deposit(
         InfoPackageService infoPackageService,
@@ -68,10 +69,11 @@ public class Deposit implements Command {
         }
 
         this.repositoryClient = repositoryClientRegistry.getClient(repositoryName);
+        this.sourcePackage = depositDir.getPackage(sourcePath);
+        this.sourcePackage.validatePath();
     }
 
     public void execute() {
-        Package sourcePackage = depositDir.getPackage(sourcePath);
         repositoryClient.createObject(
             packageIdentifier, sourcePackage.getRootPath(), curator, message
         );

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Deposit.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Deposit.java
@@ -70,7 +70,6 @@ public class Deposit implements Command {
 
         this.repositoryClient = repositoryClientRegistry.getClient(repositoryName);
         this.sourcePackage = depositDir.getPackage(sourcePath);
-        this.sourcePackage.validatePath();
     }
 
     public void execute() {

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
@@ -41,11 +41,11 @@ public class OcflFilesystemRepositoryClient implements RepositoryClient {
     }
 
     public RepositoryClient createObject(
-        String id, Path inputPath, Curator curator, String message
+        String id, Package sourcePackage, Curator curator, String message
     ) {
         repo.putObject(
             ObjectVersionId.head(id),
-            inputPath,
+            sourcePackage.getRootPath(),
             createNewVersion(curator, message)
         );
         return this;
@@ -105,15 +105,16 @@ public class OcflFilesystemRepositoryClient implements RepositoryClient {
     }
 
     public RepositoryClient updateObjectFiles(
-        String objectId, Path updatePackagePath, List<Path> inputPaths, Curator curator, String message
+        String objectId, Package sourcePackage, Curator curator, String message
     ) {
+        Path rootPackagePath = sourcePackage.getRootPath();
         repo.updateObject(
             ObjectVersionId.head(objectId),
             createNewVersion(curator, message),
             updater -> {
-                for (Path inputPath : inputPaths) {
+                for (Path inputPath : sourcePackage.getFilePaths()) {
                     updater.addPath(
-                        updatePackagePath.resolve(inputPath),
+                        rootPackagePath.resolve(inputPath),
                         inputPath.toString(),
                         OcflOption.OVERWRITE
                     );

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
@@ -19,7 +19,8 @@ import org.slf4j.LoggerFactory;
 import edu.umich.lib.dor.replicaexperiment.domain.Curator;
 
 public class OcflFilesystemRepositoryClient implements RepositoryClient {
-	private static final Logger log = LoggerFactory.getLogger(OcflFilesystemRepositoryClient.class);
+    private static final Logger log = LoggerFactory
+        .getLogger(OcflFilesystemRepositoryClient.class);
 
     private OcflRepository repo;
 

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
@@ -1,13 +1,10 @@
 package edu.umich.lib.dor.replicaexperiment.service;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import io.ocfl.api.OcflOption;
 import io.ocfl.api.OcflRepository;
 import io.ocfl.api.model.FileDetails;
@@ -16,9 +13,10 @@ import io.ocfl.api.model.ObjectVersionId;
 import io.ocfl.api.model.VersionInfo;
 import io.ocfl.core.OcflRepositoryBuilder;
 import io.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.umich.lib.dor.replicaexperiment.domain.Curator;
-import edu.umich.lib.dor.replicaexperiment.exception.NoContentException;
 
 public class OcflFilesystemRepositoryClient implements RepositoryClient {
 	private static final Logger log = LoggerFactory.getLogger(OcflFilesystemRepositoryClient.class);
@@ -34,20 +32,17 @@ public class OcflFilesystemRepositoryClient implements RepositoryClient {
             .build();
     }
 
+    public OcflFilesystemRepositoryClient(OcflRepository repository) {
+        this.repo = repository;
+    }
+
     private VersionInfo createNewVersion(Curator curator, String message) {
         return new VersionInfo().setUser(curator.username(), curator.email()).setMessage(message);
     }
 
-    private void validatePath(Path path) {
-        if (!Files.exists(path)) {
-            throw new NoContentException(
-                String.format("No content exists at path %s.", path.toString())
-            );
-        }
-    }
-
-    public RepositoryClient createObject(String id, Path inputPath, Curator curator, String message) {
-        validatePath(inputPath);
+    public RepositoryClient createObject(
+        String id, Path inputPath, Curator curator, String message
+    ) {
         repo.putObject(
             ObjectVersionId.head(id),
             inputPath,
@@ -130,7 +125,6 @@ public class OcflFilesystemRepositoryClient implements RepositoryClient {
 
     public RepositoryClient importObject(Path inputPath) {
         // TO DO: Is MOVE_SOURCE OK? Keeps staging clear
-        validatePath(inputPath);
         repo.importObject(inputPath, OcflOption.MOVE_SOURCE);
         return this;
     }

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Package.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Package.java
@@ -11,21 +11,23 @@ public class Package {
     protected final DepositDirectory depositDir;
     protected final Path packagePath;
 
-    public Package(DepositDirectory depositDir, Path packagePath) {
-        this.depositDir = depositDir;
-        this.packagePath = packagePath;
-    }
-
     public Path getRootPath() {
         return depositDir.resolve(packagePath);
     }
 
-    public void validatePath() {
+    private void validatePath() {
         if (!Files.exists(getRootPath())) {
             throw new NoContentException(
                 String.format("No content exists at path %s.", packagePath.toString())
             );
         }
+    }
+
+    public Package(DepositDirectory depositDir, Path packagePath) {
+        this.depositDir = depositDir;
+        this.packagePath = packagePath;
+
+        validatePath();
     }
 
     public List<Path> getFilePaths() {

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Package.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Package.java
@@ -11,6 +11,13 @@ public class Package {
     protected final DepositDirectory depositDir;
     protected final Path packagePath;
 
+    public Package(DepositDirectory depositDir, Path packagePath) {
+        this.depositDir = depositDir;
+        this.packagePath = packagePath;
+
+        validatePath();
+    }
+
     public Path getRootPath() {
         return depositDir.resolve(packagePath);
     }
@@ -21,13 +28,6 @@ public class Package {
                 String.format("No content exists at path %s.", packagePath.toString())
             );
         }
-    }
-
-    public Package(DepositDirectory depositDir, Path packagePath) {
-        this.depositDir = depositDir;
-        this.packagePath = packagePath;
-
-        validatePath();
     }
 
     public List<Path> getFilePaths() {

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Package.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Package.java
@@ -5,6 +5,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import edu.umich.lib.dor.replicaexperiment.exception.NoContentException;
+
 public class Package {
     protected final DepositDirectory depositDir;
     protected final Path packagePath;
@@ -16,6 +18,14 @@ public class Package {
 
     public Path getRootPath() {
         return depositDir.resolve(packagePath);
+    }
+
+    public void validatePath() {
+        if (!Files.exists(getRootPath())) {
+            throw new NoContentException(
+                String.format("No content exists at path %s.", packagePath.toString())
+            );
+        }
     }
 
     public List<Path> getFilePaths() {

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/RepositoryClient.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/RepositoryClient.java
@@ -6,7 +6,7 @@ import java.util.List;
 import edu.umich.lib.dor.replicaexperiment.domain.Curator;
 
 public interface RepositoryClient {
-    RepositoryClient createObject(String id, Package sourcPackage, Curator curator, String message);
+    RepositoryClient createObject(String id, Package sourcePackage, Curator curator, String message);
 
     RepositoryClient readObject(String id, Path outputPath);
 

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/RepositoryClient.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/RepositoryClient.java
@@ -6,7 +6,7 @@ import java.util.List;
 import edu.umich.lib.dor.replicaexperiment.domain.Curator;
 
 public interface RepositoryClient {
-    RepositoryClient createObject(String id, Path inputPath, Curator curator, String message);
+    RepositoryClient createObject(String id, Package sourcPackage, Curator curator, String message);
 
     RepositoryClient readObject(String id, Path outputPath);
 
@@ -17,7 +17,7 @@ public interface RepositoryClient {
     RepositoryClient deleteObjectFile(String objectId, String filePath, Curator curator, String message);
 
     RepositoryClient updateObjectFiles(
-        String objectId, Path updatePackagePath, List<Path> inputPaths, Curator curator, String message
+        String objectId, Package sourcePackage, Curator curator, String message
     );
 
     List<Path> getFilePaths(String id);

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
@@ -87,8 +87,7 @@ public class Update implements Command {
     public void execute() {
         repositoryClient.updateObjectFiles(
             packageIdentifier,
-            sourcePackage.getRootPath(),
-            sourcePackage.getFilePaths(),
+            sourcePackage,
             curator,
             message
         );

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
@@ -81,6 +81,7 @@ public class Update implements Command {
         }
 
         this.sourcePackage = depositDir.getPackage(sourcePath);
+        this.sourcePackage.validatePath();
     }
 
     public void execute() {

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
@@ -81,7 +81,6 @@ public class Update implements Command {
         }
 
         this.sourcePackage = depositDir.getPackage(sourcePath);
-        this.sourcePackage.validatePath();
     }
 
     public void execute() {

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositDirectoryTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositDirectoryTest.java
@@ -28,7 +28,7 @@ public class DepositDirectoryTest {
 
     @Test
     public void depositDirectoryProvidesAccessToPackages() {
-        var packagePath = Paths.get("some_package");
+        var packagePath = Paths.get("deposit_one");
         depositDir.getPackage(packagePath);
     }
 }

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
@@ -44,7 +44,6 @@ public class DepositTest {
     OcflFilesystemRepositoryClient clientMock;
     Package sourcePackageMock;
 
-
     @BeforeEach
     void init() {
         this.packageServiceMock = mock(InfoPackageService.class);

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
@@ -83,7 +83,6 @@ public class DepositTest {
                 "we're good"
             );
         });
-        verify(sourcePackageMock).validatePath();
     }
 
     @Test
@@ -102,22 +101,6 @@ public class DepositTest {
     }
 
     @Test
-    void depositFailsWhenRepositoryDoesNotExist() {
-        when(packageServiceMock.getInfoPackage("A")).thenReturn(null);
-        when(repositoryServiceMock.getRepository("some_repo")).thenReturn(null);
-
-        assertThrows(NoEntityException.class, () -> {
-            depositFactory.create(
-                testCurator,
-                "A",
-                Paths.get("/something"),
-                "some_repo",
-                "was there a some_repo?"
-            );
-        });
-    }
-
-    @Test
     void depositExecutes() {
         when(packageServiceMock.getInfoPackage("A")).thenReturn(null);
         when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
@@ -131,7 +114,6 @@ public class DepositTest {
             "some_repo",
             "we're good"
         );
-        verify(sourcePackageMock).validatePath();
 
         when(packageServiceMock.createInfoPackage("A")).thenReturn(infoPackageMock);
 

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
@@ -30,12 +30,14 @@ import edu.umich.lib.dor.replicaexperiment.service.RepositoryService;
 
 public class DepositTest {
     Curator testCurator = new Curator("test", "test@example.edu");
+
     InfoPackageService packageServiceMock;
     RepositoryService repositoryServiceMock;
     ReplicaService replicaServiceMock;
     RepositoryClientRegistry registryMock;
-    Path depositPath;
     DepositDirectory depositDirMock;
+
+    DepositFactory depositFactory;
 
     InfoPackage infoPackageMock;
     Repository repositoryMock;
@@ -43,7 +45,6 @@ public class DepositTest {
     OcflFilesystemRepositoryClient clientMock;
     Package sourcePackageMock;
 
-    DepositFactory depositFactory;
 
     @BeforeEach
     void init() {
@@ -52,9 +53,8 @@ public class DepositTest {
         this.replicaServiceMock = mock(ReplicaService.class);
         this.registryMock = mock(RepositoryClientRegistry.class);
         this.depositDirMock = mock(DepositDirectory.class);
-        this.sourcePackageMock = mock(Package.class);
 
-        depositFactory = new DepositFactory(
+        this.depositFactory = new DepositFactory(
             packageServiceMock,
             repositoryServiceMock,
             replicaServiceMock,
@@ -64,8 +64,9 @@ public class DepositTest {
 
         this.infoPackageMock = mock(InfoPackage.class);
         this.repositoryMock = mock(Repository.class);
-        this.clientMock = mock(OcflFilesystemRepositoryClient.class);
         this.replicaMock = mock(Replica.class);
+        this.clientMock = mock(OcflFilesystemRepositoryClient.class);
+        this.sourcePackageMock = mock(Package.class);
     }
 
     @Test

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -135,10 +134,7 @@ public class DepositTest {
         );
         verify(sourcePackageMock).validatePath();
 
-        when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("deposit/something"));
         when(packageServiceMock.createInfoPackage("A")).thenReturn(infoPackageMock);
-        when(replicaServiceMock.createReplica(infoPackageMock, repositoryMock))
-            .thenReturn(replicaMock);
 
         deposit.execute();
         verify(clientMock).createObject(

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
@@ -1,13 +1,13 @@
 package edu.umich.lib.dor.replicaexperiment;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,6 +18,7 @@ import edu.umich.lib.dor.replicaexperiment.domain.Replica;
 import edu.umich.lib.dor.replicaexperiment.domain.Repository;
 import edu.umich.lib.dor.replicaexperiment.exception.EntityAlreadyExistsException;
 import edu.umich.lib.dor.replicaexperiment.exception.NoEntityException;
+import edu.umich.lib.dor.replicaexperiment.service.Deposit;
 import edu.umich.lib.dor.replicaexperiment.service.DepositDirectory;
 import edu.umich.lib.dor.replicaexperiment.service.DepositFactory;
 import edu.umich.lib.dor.replicaexperiment.service.InfoPackageService;
@@ -83,6 +84,7 @@ public class DepositTest {
                 "we're good"
             );
         });
+        verify(sourcePackageMock).validatePath();
     }
 
     @Test
@@ -123,24 +125,21 @@ public class DepositTest {
         when(registryMock.getClient("some_repo")).thenReturn(clientMock);
         when(depositDirMock.getPackage(Paths.get("something"))).thenReturn(sourcePackageMock);
 
-        final var deposit = depositFactory.create(
+        final Deposit deposit = depositFactory.create(
             testCurator,
             "A",
             Paths.get("something"),
             "some_repo",
             "we're good"
         );
-
         verify(sourcePackageMock).validatePath();
 
-        when(depositDirMock.getPackage(Paths.get("something"))).thenReturn(sourcePackageMock);
         when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("deposit/something"));
         when(packageServiceMock.createInfoPackage("A")).thenReturn(infoPackageMock);
         when(replicaServiceMock.createReplica(infoPackageMock, repositoryMock))
             .thenReturn(replicaMock);
 
         deposit.execute();
-
         verify(clientMock).createObject(
             "A", sourcePackageMock, testCurator, "we're good"
         );

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
@@ -35,14 +35,14 @@ public class DepositTest {
     RepositoryClientRegistry registryMock;
     Path depositPath;
     DepositDirectory depositDirMock;
-    Package packageMock;
-
-    DepositFactory depositFactory;
 
     InfoPackage infoPackageMock;
     Repository repositoryMock;
-    OcflFilesystemRepositoryClient clientMock;
     Replica replicaMock;
+    OcflFilesystemRepositoryClient clientMock;
+    Package sourcePackageMock;
+
+    DepositFactory depositFactory;
 
     @BeforeEach
     void init() {
@@ -51,7 +51,7 @@ public class DepositTest {
         this.replicaServiceMock = mock(ReplicaService.class);
         this.registryMock = mock(RepositoryClientRegistry.class);
         this.depositDirMock = mock(DepositDirectory.class);
-        this.packageMock = mock(Package.class);
+        this.sourcePackageMock = mock(Package.class);
 
         depositFactory = new DepositFactory(
             packageServiceMock,
@@ -72,7 +72,8 @@ public class DepositTest {
         when(packageServiceMock.getInfoPackage("A")).thenReturn(null);
         when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
         when(registryMock.getClient("some_repo")).thenReturn(clientMock);
-    
+        when(depositDirMock.getPackage(Paths.get("something"))).thenReturn(sourcePackageMock);
+
         assertDoesNotThrow(() -> {
             depositFactory.create(
                 testCurator,
@@ -120,6 +121,7 @@ public class DepositTest {
         when(packageServiceMock.getInfoPackage("A")).thenReturn(null);
         when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
         when(registryMock.getClient("some_repo")).thenReturn(clientMock);
+        when(depositDirMock.getPackage(Paths.get("something"))).thenReturn(sourcePackageMock);
 
         final var deposit = depositFactory.create(
             testCurator,
@@ -129,8 +131,10 @@ public class DepositTest {
             "we're good"
         );
 
-        when(depositDirMock.getPackage(Paths.get("something"))).thenReturn(packageMock);
-        when(packageMock.getRootPath()).thenReturn(Paths.get("deposit/something"));
+        verify(sourcePackageMock).validatePath();
+
+        when(depositDirMock.getPackage(Paths.get("something"))).thenReturn(sourcePackageMock);
+        when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("deposit/something"));
         when(packageServiceMock.createInfoPackage("A")).thenReturn(infoPackageMock);
         when(replicaServiceMock.createReplica(infoPackageMock, repositoryMock))
             .thenReturn(replicaMock);

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/DepositTest.java
@@ -142,7 +142,7 @@ public class DepositTest {
         deposit.execute();
 
         verify(clientMock).createObject(
-            "A", Paths.get("deposit/something"), testCurator, "we're good"
+            "A", sourcePackageMock, testCurator, "we're good"
         );
         verify(packageServiceMock).createInfoPackage("A");
         verify(replicaServiceMock).createReplica(infoPackageMock, repositoryMock);

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
@@ -22,15 +22,18 @@ import org.mockito.ArgumentMatchers;
 
 import edu.umich.lib.dor.replicaexperiment.domain.Curator;
 import edu.umich.lib.dor.replicaexperiment.service.OcflFilesystemRepositoryClient;
+import edu.umich.lib.dor.replicaexperiment.service.Package;
 import edu.umich.lib.dor.replicaexperiment.service.RepositoryClient;
 
 public class OcflFilesystemRepositoryClientTest {
     OcflRepository ocflRepositoryMock;
     OcflFilesystemRepositoryClient repositoryClient;
+    Package sourcePackageMock;
 
     @BeforeEach
     public void init() {
         ocflRepositoryMock = mock(OcflRepository.class);
+        sourcePackageMock = mock(Package.class);
     }
 
     @Test
@@ -40,10 +43,12 @@ public class OcflFilesystemRepositoryClientTest {
 
     @Test
     public void clientCreatesObject() {
+        when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("some/path/deposit_A"));
+
         RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
         repositoryClient.createObject(
             "A",
-            Paths.get("some/path/deposit_A"),
+            sourcePackageMock,
             new Curator("test", "test@example.edu"),
             "adding images and metadata"
         );
@@ -61,6 +66,11 @@ public class OcflFilesystemRepositoryClientTest {
     public void clientUpdatesObject() {
         RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
         
+        when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("some/path/update_A"));
+        when(sourcePackageMock.getFilePaths()).thenReturn(List.of(
+            Paths.get("A.txt"), Paths.get("B/C.txt")
+        ));
+
         when(ocflRepositoryMock.updateObject(
             any(ObjectVersionId.class),
             any(VersionInfo.class),
@@ -94,10 +104,10 @@ public class OcflFilesystemRepositoryClientTest {
                 );
                 return versionId;
             });
+
         repositoryClient.updateObjectFiles(
             "A",
-            Paths.get("some/path/update_A"),
-            List.of(Paths.get("A.txt"), Paths.get("B/C.txt")),
+            sourcePackageMock,
             new Curator("test", "test@example.edu"),
             "Updating files"
         );

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
@@ -48,6 +48,7 @@ public class OcflFilesystemRepositoryClientTest {
         fileaDetails.setPath("test.txt");
         fileaDetails.setStorageRelativePath("storage/A/test.txt");
 
+        
         var fileMap = new HashMap<String, FileDetails>();
         fileMap.put("A", fileaDetails);
         var versionDetails = new VersionDetails();

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
@@ -29,7 +29,6 @@ import org.mockito.ArgumentMatchers;
 import edu.umich.lib.dor.replicaexperiment.domain.Curator;
 import edu.umich.lib.dor.replicaexperiment.service.OcflFilesystemRepositoryClient;
 import edu.umich.lib.dor.replicaexperiment.service.Package;
-import edu.umich.lib.dor.replicaexperiment.service.RepositoryClient;
 
 public class OcflFilesystemRepositoryClientTest {
     OcflRepository ocflRepositoryMock;
@@ -43,7 +42,7 @@ public class OcflFilesystemRepositoryClientTest {
         repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
     }
 
-    public ObjectDetails createObjectDetails() {
+    private ObjectDetails createObjectDetails() {
         var fileaDetails = new FileDetails();
         fileaDetails.setPath("test.txt");
         fileaDetails.setStorageRelativePath("storage/A/test.txt");

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
@@ -1,7 +1,6 @@
 package edu.umich.lib.dor.replicaexperiment;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -38,8 +37,8 @@ public class OcflFilesystemRepositoryClientTest {
     @BeforeEach
     public void init() {
         ocflRepositoryMock = mock(OcflRepository.class);
-        sourcePackageMock = mock(Package.class);
         repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
+        sourcePackageMock = mock(Package.class);
     }
 
     private ObjectDetails createObjectDetails() {
@@ -47,7 +46,6 @@ public class OcflFilesystemRepositoryClientTest {
         fileaDetails.setPath("test.txt");
         fileaDetails.setStorageRelativePath("storage/A/test.txt");
 
-        
         var fileMap = new HashMap<String, FileDetails>();
         fileMap.put("A", fileaDetails);
         var versionDetails = new VersionDetails();
@@ -56,7 +54,6 @@ public class OcflFilesystemRepositoryClientTest {
         var versionMap = new HashMap<VersionNum, VersionDetails>();
         var versionNum = new VersionNum(1);
         versionMap.put(versionNum, versionDetails);
-
         var details = new ObjectDetails();
         details.setId("A");
         details.setHeadVersionNum(versionNum);
@@ -65,7 +62,7 @@ public class OcflFilesystemRepositoryClientTest {
     }
 
     @Test
-    public void clientWithInjectedCreationWorks() {
+    public void clientWithInjectedRepositoryWorks() {
         new OcflFilesystemRepositoryClient(ocflRepositoryMock);
     }
 

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
@@ -1,0 +1,105 @@
+package edu.umich.lib.dor.replicaexperiment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.ocfl.api.OcflObjectUpdater;
+import io.ocfl.api.OcflOption;
+import io.ocfl.api.OcflRepository;
+import io.ocfl.api.model.ObjectVersionId;
+import io.ocfl.api.model.User;
+import io.ocfl.api.model.VersionInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import edu.umich.lib.dor.replicaexperiment.domain.Curator;
+import edu.umich.lib.dor.replicaexperiment.service.OcflFilesystemRepositoryClient;
+import edu.umich.lib.dor.replicaexperiment.service.RepositoryClient;
+
+public class OcflFilesystemRepositoryClientTest {
+    OcflRepository ocflRepositoryMock;
+    OcflFilesystemRepositoryClient repositoryClient;
+
+    @BeforeEach
+    public void init() {
+        ocflRepositoryMock = mock(OcflRepository.class);
+    }
+
+    @Test
+    public void clientWithInjectedCreationWorks() {
+        new OcflFilesystemRepositoryClient(ocflRepositoryMock);
+    }
+
+    @Test
+    public void clientCreatesObject() {
+        RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
+        repositoryClient.createObject(
+            "A",
+            Paths.get("some/path/deposit_A"),
+            new Curator("test", "test@example.edu"),
+            "adding images and metadata"
+        );
+
+        verify(ocflRepositoryMock).putObject(
+            ObjectVersionId.head("A"),
+            Paths.get("some/path/deposit_A"),
+            new VersionInfo().setUser(
+                "test", "test@example.edu"
+            ).setMessage("adding images and metadata")
+        );
+    }
+
+    @Test
+    public void clientUpdatesObject() {
+        RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
+        
+        when(ocflRepositoryMock.updateObject(
+            any(ObjectVersionId.class),
+            any(VersionInfo.class),
+            ArgumentMatchers.<Consumer<OcflObjectUpdater>>any()
+        ))
+            .then((invocationOnMock) -> {
+                var args = invocationOnMock.getArguments();
+
+                ObjectVersionId versionId = (ObjectVersionId) args[0];
+                assertEquals("A", versionId.getObjectId());
+
+                VersionInfo versionInfo = (VersionInfo) args[1];
+                assertEquals("Updating files", versionInfo.getMessage());
+                User user = versionInfo.getUser();
+                assertEquals("test", user.getName());
+                assertEquals("test@example.edu", user.getAddress());
+
+                Consumer<OcflObjectUpdater> updaterLambda = invocationOnMock.getArgument(2);
+                OcflObjectUpdater updaterMock = mock(OcflObjectUpdater.class);
+                updaterLambda.accept(updaterMock);
+
+                verify(updaterMock).addPath(
+                    Paths.get("some/path/update_A/A.txt"),
+                    "A.txt",
+                    OcflOption.OVERWRITE
+                );
+                verify(updaterMock).addPath(
+                    Paths.get("some/path/update_A/B/C.txt"),
+                    "B/C.txt",
+                    OcflOption.OVERWRITE
+                );
+                return versionId;
+            });
+        repositoryClient.updateObjectFiles(
+            "A",
+            Paths.get("some/path/update_A"),
+            List.of(Paths.get("A.txt"), Paths.get("B/C.txt")),
+            new Curator("test", "test@example.edu"),
+            "Updating files"
+        );
+    }
+}

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
@@ -40,6 +40,7 @@ public class OcflFilesystemRepositoryClientTest {
     public void init() {
         ocflRepositoryMock = mock(OcflRepository.class);
         sourcePackageMock = mock(Package.class);
+        repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
     }
 
     public ObjectDetails createObjectDetails() {
@@ -72,7 +73,6 @@ public class OcflFilesystemRepositoryClientTest {
     public void clientCreatesObject() {
         when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("some/path/deposit_A"));
 
-        RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
         repositoryClient.createObject(
             "A",
             sourcePackageMock,
@@ -91,10 +91,6 @@ public class OcflFilesystemRepositoryClientTest {
 
     @Test
     public void clientUpdatesObject() {
-        final RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(
-            ocflRepositoryMock
-        );
-        
         when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("some/path/update_A"));
         when(sourcePackageMock.getFilePaths()).thenReturn(List.of(
             Paths.get("A.txt"), Paths.get("B/C.txt")
@@ -144,7 +140,6 @@ public class OcflFilesystemRepositoryClientTest {
 
     @Test
     public void clientGetsPackagePaths() {
-        RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
         when(ocflRepositoryMock.describeObject("A"))
             .thenReturn(createObjectDetails());
         var filePaths = repositoryClient.getFilePaths("A");
@@ -153,7 +148,6 @@ public class OcflFilesystemRepositoryClientTest {
 
     @Test
     public void clientGetsStoragePackagePaths() {
-        RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
         when(ocflRepositoryMock.describeObject("A"))
             .thenReturn(createObjectDetails());
         var filePaths = repositoryClient.getStorageFilePaths("A");
@@ -162,14 +156,12 @@ public class OcflFilesystemRepositoryClientTest {
 
     @Test
     public void clientExportsObject() {
-        RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
         repositoryClient.exportObject("A", Paths.get("some/path/staging/A"));
         verify(ocflRepositoryMock).exportObject("A", Paths.get("some/path/staging/A"));
     }
 
     @Test
     public void clientImportsObject() {
-        RepositoryClient repositoryClient = new OcflFilesystemRepositoryClient(ocflRepositoryMock);
         repositoryClient.importObject(Paths.get("some/path/staging/A"));
         verify(ocflRepositoryMock).importObject(
             Paths.get("some/path/staging/A"), OcflOption.MOVE_SOURCE

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/PackageTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/PackageTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umich.lib.dor.replicaexperiment.exception.NoContentException;
 import edu.umich.lib.dor.replicaexperiment.service.DepositDirectory;
 import edu.umich.lib.dor.replicaexperiment.service.Package;
 
@@ -42,6 +43,27 @@ public class PackageTest {
             Paths.get("deposit_one")
         );
         assertEquals(testDepositPath.resolve("deposit_one"), pkg.getRootPath());
+    }
+
+
+    @Test
+    public void existingPackagePassesValidation() {
+        assertDoesNotThrow(() -> {
+            new Package(
+                new DepositDirectory(testDepositPath),
+                Paths.get("deposit_one")
+            ).validatePath();
+        });
+    }
+
+    @Test
+    public void nonexistentPackageFailsValidation() {
+        assertThrows(NoContentException.class, () -> {
+            new Package(
+                new DepositDirectory(testDepositPath),
+                Paths.get("no_such_deposit")
+            ).validatePath();
+        });
     }
 
     @Test

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/PackageTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/PackageTest.java
@@ -45,14 +45,13 @@ public class PackageTest {
         assertEquals(testDepositPath.resolve("deposit_one"), pkg.getRootPath());
     }
 
-
     @Test
     public void existingPackagePassesValidation() {
         assertDoesNotThrow(() -> {
             new Package(
                 new DepositDirectory(testDepositPath),
                 Paths.get("deposit_one")
-            ).validatePath();
+            );
         });
     }
 
@@ -62,7 +61,7 @@ public class PackageTest {
             new Package(
                 new DepositDirectory(testDepositPath),
                 Paths.get("no_such_deposit")
-            ).validatePath();
+            );
         });
     }
 

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
@@ -86,7 +86,6 @@ public class UpdateTest {
                 "we're good"
             );
         });
-        verify(sourcePackageMock).validatePath();
     }
 
     @Test
@@ -100,23 +99,6 @@ public class UpdateTest {
                 Paths.get("update_A"),
                 "some_repo",
                 "did I not add this yet?"
-            );
-        });
-    }
-
-
-    @Test
-    void updateFailsWhenRepositoryDoesNotExist() {
-        when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
-        when(repositoryServiceMock.getRepository("some_repo")).thenReturn(null);
-
-        assertThrows(NoEntityException.class, () -> {
-            updateFactory.create(
-                testCurator,
-                "A",
-                Paths.get("update_A"),
-                "some_repo",
-                "was there a some_repo?"
             );
         });
     }
@@ -160,7 +142,6 @@ public class UpdateTest {
             "some_repo",
             "we're good"
         );
-        verify(sourcePackageMock).validatePath();
 
         update.execute();
         verify(clientMock).updateObjectFiles(

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
@@ -34,15 +34,16 @@ public class UpdateTest {
     RepositoryService repositoryServiceMock;
     ReplicaService replicaServiceMock;
     RepositoryClientRegistry registryMock;
+    DepositDirectory depositDirMock;
+
+    UpdateFactory updateFactory;
 
     InfoPackage infoPackageMock;
     Repository repositoryMock;
     Replica replicaMock;
     OcflFilesystemRepositoryClient clientMock;
-    DepositDirectory depositDirMock;
     Package sourcePackageMock;
 
-    UpdateFactory updateFactory;
 
     @BeforeEach
     void init() {
@@ -50,14 +51,7 @@ public class UpdateTest {
         this.repositoryServiceMock = mock(RepositoryService.class);
         this.replicaServiceMock = mock(ReplicaService.class);
         this.registryMock = mock(RepositoryClientRegistry.class);
-        
-        this.infoPackageMock = mock(InfoPackage.class);
-        this.repositoryMock = mock(Repository.class);
-        this.replicaMock = mock(Replica.class);
-        this.clientMock = mock(OcflFilesystemRepositoryClient.class);
-
         this.depositDirMock = mock(DepositDirectory.class);
-        this.sourcePackageMock = mock(Package.class);
 
         this.updateFactory = new UpdateFactory(
             packageServiceMock,
@@ -66,6 +60,12 @@ public class UpdateTest {
             registryMock,
             depositDirMock
         );
+
+        this.infoPackageMock = mock(InfoPackage.class);
+        this.repositoryMock = mock(Repository.class);
+        this.replicaMock = mock(Replica.class);
+        this.clientMock = mock(OcflFilesystemRepositoryClient.class);
+        this.sourcePackageMock = mock(Package.class);
     }
 
     @Test

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
@@ -167,8 +167,7 @@ public class UpdateTest {
 
         verify(clientMock).updateObjectFiles(
             "A",
-            Paths.get("some/path/update_A"),
-            newPackagePaths,
+            sourcePackageMock,
             testCurator,
             "we're good"
         );

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
@@ -86,6 +86,7 @@ public class UpdateTest {
                 "we're good"
             );
         });
+        verify(sourcePackageMock).validatePath();
     }
 
     @Test

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
@@ -1,13 +1,13 @@
 package edu.umich.lib.dor.replicaexperiment;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -152,19 +152,20 @@ public class UpdateTest {
         );
 
         when(depositDirMock.getPackage(Paths.get("update_A"))).thenReturn(sourcePackageMock);
-        when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("some/path/update_A"));
-        when(sourcePackageMock.getFilePaths()).thenReturn(newPackagePaths);
 
-        Update update = updateFactory.create(
+        final Update update = updateFactory.create(
             testCurator,
             "A",
             Paths.get("update_A"),
             "some_repo",
             "we're good"
         );
+        verify(sourcePackageMock).validatePath();
+
+        when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("some/path/update_A"));
+        when(sourcePackageMock.getFilePaths()).thenReturn(newPackagePaths);
 
         update.execute();
-
         verify(clientMock).updateObjectFiles(
             "A",
             sourcePackageMock,

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
@@ -162,9 +162,6 @@ public class UpdateTest {
         );
         verify(sourcePackageMock).validatePath();
 
-        when(sourcePackageMock.getRootPath()).thenReturn(Paths.get("some/path/update_A"));
-        when(sourcePackageMock.getFilePaths()).thenReturn(newPackagePaths);
-
         update.execute();
         verify(clientMock).updateObjectFiles(
             "A",


### PR DESCRIPTION
Closes #15.

- [x] Move `validatePath` to `Package`
- [x] Add tests for used `OcflFilesystemRepositoryClient` methods
  - [x] `createObject`
  - [x] `updateObjectFiles`
  - [x] `getFilePaths(String id)`
  - [x] `getStorageFilePaths(String id)`
  - [x] `importObject(Path inputPath)`
  - [x] `exportObject(String objectId, Path outputPath)`
- [x] Pass `Package` into `createObject`, `updateObjectFiles`

Resource(s)
- https://stackoverflow.com/a/77408468
- https://stackoverflow.com/q/54818305