### PR TITLE
Add Purge Command (#19)

### DIFF
--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/AppConfig.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/AppConfig.java
@@ -15,6 +15,7 @@ import edu.umich.lib.dor.replicaexperiment.service.DepositDirectory;
 import edu.umich.lib.dor.replicaexperiment.service.DepositFactory;
 import edu.umich.lib.dor.replicaexperiment.service.InfoPackageService;
 import edu.umich.lib.dor.replicaexperiment.service.OcflFilesystemRepositoryClient;
+import edu.umich.lib.dor.replicaexperiment.service.PurgeFactory;
 import edu.umich.lib.dor.replicaexperiment.service.ReplicaService;
 import edu.umich.lib.dor.replicaexperiment.service.ReplicationFactory;
 import edu.umich.lib.dor.replicaexperiment.service.RepositoryClient;
@@ -128,6 +129,21 @@ public class AppConfig {
             replicaService,
             repositoryClientRegistry,
             stagingPath
+        );
+    }
+
+    @Bean
+    public PurgeFactory purgeFactory(
+        RepositoryClientRegistry repositoryClientRegistry,
+        RepositoryService repositoryService,
+        InfoPackageService infoPackageService,
+        ReplicaService replicaService
+    ) {
+        return new PurgeFactory(
+            infoPackageService,
+            repositoryService,
+            replicaService,
+            repositoryClientRegistry
         );
     }
 }

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/controllers/InfoPackageController.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/controllers/InfoPackageController.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -19,6 +20,8 @@ import edu.umich.lib.dor.replicaexperiment.domain.InfoPackage;
 import edu.umich.lib.dor.replicaexperiment.service.Deposit;
 import edu.umich.lib.dor.replicaexperiment.service.DepositFactory;
 import edu.umich.lib.dor.replicaexperiment.service.InfoPackageService;
+import edu.umich.lib.dor.replicaexperiment.service.Purge;
+import edu.umich.lib.dor.replicaexperiment.service.PurgeFactory;
 import edu.umich.lib.dor.replicaexperiment.service.Replication;
 import edu.umich.lib.dor.replicaexperiment.service.ReplicationFactory;
 import edu.umich.lib.dor.replicaexperiment.service.Update;
@@ -40,6 +43,9 @@ public class InfoPackageController {
 
     @Autowired
     private ReplicationFactory replicationFactory;
+
+    @Autowired
+    private PurgeFactory purgeFactory;
 
     @PostMapping(path="/deposit")
     public @ResponseBody InfoPackageDto deposit(
@@ -85,6 +91,16 @@ public class InfoPackageController {
         replication.execute();
         var newInfoPackage = infoPackageService.getInfoPackage(identifier);
         return new InfoPackageDto(newInfoPackage);
+    }
+
+    @DeleteMapping(path="/purge")
+    public @ResponseBody String purge(
+        @RequestParam String identifier,
+        @RequestParam String repository
+    ) {
+        Purge purge = purgeFactory.create(identifier, repository);
+        purge.execute();
+        return "Purged";
     }
 
     @GetMapping(path="/all")

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/OcflFilesystemRepositoryClient.java
@@ -57,7 +57,7 @@ public class OcflFilesystemRepositoryClient implements RepositoryClient {
         return this;
     }
 
-    public RepositoryClient deleteObject(String id) {
+    public RepositoryClient purgeObject(String id) {
         repo.purgeObject(id);
         return this;
     }

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Purge.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Purge.java
@@ -1,0 +1,75 @@
+package edu.umich.lib.dor.replicaexperiment.service;
+
+import edu.umich.lib.dor.replicaexperiment.domain.InfoPackage;
+import edu.umich.lib.dor.replicaexperiment.domain.Replica;
+import edu.umich.lib.dor.replicaexperiment.domain.Repository;
+import edu.umich.lib.dor.replicaexperiment.exception.NoEntityException;
+
+public class Purge implements Command {
+    private InfoPackageService packageService;
+    private RepositoryService repositoryService;
+    private ReplicaService replicaService;
+    private RepositoryClientRegistry clientRegistry;
+    private String packageIdentifier;
+    private String repositoryName;
+
+    private InfoPackage infoPackage;
+    private Repository repository;
+    private Replica replica; 
+
+    private RepositoryClient repositoryClient;
+
+    public Purge(
+        InfoPackageService packageService,
+        RepositoryService repositoryService,
+        ReplicaService replicaService,
+        RepositoryClientRegistry clientRegistry,
+        String packageIdentifier,
+        String repositoryName
+    ) {
+        this.packageService = packageService;
+        this.repositoryService = repositoryService;
+        this.replicaService = replicaService;
+        this.clientRegistry = clientRegistry;
+        this.packageIdentifier = packageIdentifier;
+        this.repositoryName = repositoryName;
+
+        this.packageIdentifier = packageIdentifier;
+        this.infoPackage = packageService.getInfoPackage(packageIdentifier);
+        if (infoPackage == null) {
+            throw new NoEntityException(
+                String.format(
+                    "No packaged with identifier \"%s\" was found.",
+                    packageIdentifier
+                )
+            );
+        }
+
+        this.repository = repositoryService.getRepository(repositoryName);
+        if (repository == null) {
+            throw new NoEntityException(
+                String.format(
+                    "No repository with name \"%s\" was found.",
+                    repositoryName
+                )
+            );
+        }
+
+        this.repositoryClient = clientRegistry.getClient(repositoryName);
+        this.replica = this.replicaService.getReplica(infoPackage, repository);
+        if (replica == null) {
+            throw new NoEntityException(
+                String.format(
+                    "No replica for package \"%s\" was found in repository \"%s\".",
+                    packageIdentifier,
+                    repositoryName
+                )
+            );
+        }
+    }
+
+    public void execute() {
+        repositoryClient.purgeObject(packageIdentifier);
+        replicaService.deleteReplica(replica);
+    }
+}

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Purge.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Purge.java
@@ -6,17 +6,10 @@ import edu.umich.lib.dor.replicaexperiment.domain.Repository;
 import edu.umich.lib.dor.replicaexperiment.exception.NoEntityException;
 
 public class Purge implements Command {
-    private InfoPackageService packageService;
-    private RepositoryService repositoryService;
     private ReplicaService replicaService;
-    private RepositoryClientRegistry clientRegistry;
     private String packageIdentifier;
-    private String repositoryName;
 
-    private InfoPackage infoPackage;
-    private Repository repository;
-    private Replica replica; 
-
+    private Replica replica;
     private RepositoryClient repositoryClient;
 
     public Purge(
@@ -27,15 +20,10 @@ public class Purge implements Command {
         String packageIdentifier,
         String repositoryName
     ) {
-        this.packageService = packageService;
-        this.repositoryService = repositoryService;
         this.replicaService = replicaService;
-        this.clientRegistry = clientRegistry;
         this.packageIdentifier = packageIdentifier;
-        this.repositoryName = repositoryName;
 
-        this.packageIdentifier = packageIdentifier;
-        this.infoPackage = packageService.getInfoPackage(packageIdentifier);
+        InfoPackage infoPackage = packageService.getInfoPackage(packageIdentifier);
         if (infoPackage == null) {
             throw new NoEntityException(
                 String.format(
@@ -45,7 +33,7 @@ public class Purge implements Command {
             );
         }
 
-        this.repository = repositoryService.getRepository(repositoryName);
+        Repository repository = repositoryService.getRepository(repositoryName);
         if (repository == null) {
             throw new NoEntityException(
                 String.format(
@@ -54,8 +42,8 @@ public class Purge implements Command {
                 )
             );
         }
-
         this.repositoryClient = clientRegistry.getClient(repositoryName);
+
         this.replica = this.replicaService.getReplica(infoPackage, repository);
         if (replica == null) {
             throw new NoEntityException(

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/PurgeFactory.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/PurgeFactory.java
@@ -3,18 +3,18 @@ package edu.umich.lib.dor.replicaexperiment.service;
 public class PurgeFactory {
     private InfoPackageService infoPackageService;
     private RepositoryService repositoryService;
-    private ReplicaService replicaservice;
+    private ReplicaService replicaService;
     private RepositoryClientRegistry repositoryClientRegistry;
 
     public PurgeFactory(
         InfoPackageService infoPackageService,
         RepositoryService repositoryService,
-        ReplicaService replicaservice,
+        ReplicaService replicaService,
         RepositoryClientRegistry repositoryClientRegistry
     ) {
         this.infoPackageService = infoPackageService;
         this.repositoryService = repositoryService;
-        this.replicaservice = replicaservice;
+        this.replicaService = replicaService;
         this.repositoryClientRegistry = repositoryClientRegistry;
     }
 
@@ -25,7 +25,7 @@ public class PurgeFactory {
         return new Purge(
             infoPackageService,
             repositoryService,
-            replicaservice,
+            replicaService,
             repositoryClientRegistry,
             packageIdentifier,
             repositoryName

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/PurgeFactory.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/PurgeFactory.java
@@ -1,0 +1,34 @@
+package edu.umich.lib.dor.replicaexperiment.service;
+
+public class PurgeFactory {
+    private InfoPackageService infoPackageService;
+    private RepositoryService repositoryService;
+    private ReplicaService replicaservice;
+    private RepositoryClientRegistry repositoryClientRegistry;
+
+    public PurgeFactory(
+        InfoPackageService infoPackageService,
+        RepositoryService repositoryService,
+        ReplicaService replicaservice,
+        RepositoryClientRegistry repositoryClientRegistry
+    ) {
+        this.infoPackageService = infoPackageService;
+        this.repositoryService = repositoryService;
+        this.replicaservice = replicaservice;
+        this.repositoryClientRegistry = repositoryClientRegistry;
+    }
+
+    public Purge create(
+        String packageIdentifier,
+        String repositoryName
+    ) {
+        return new Purge(
+            infoPackageService,
+            repositoryService,
+            replicaservice,
+            repositoryClientRegistry,
+            packageIdentifier,
+            repositoryName
+        );
+    }
+}

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/ReplicaService.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/ReplicaService.java
@@ -45,10 +45,7 @@ public class ReplicaService {
         return matchingReplicas.getFirst();
     }
 
-    public Replica updateReplica(
-        InfoPackage infoPackage, Repository repository
-    ) {
-        var replica = getReplica(infoPackage, repository);
+    public Replica updateReplica(Replica replica) {
         replica.setUpdatedAt(Instant.now());
         replicaRepo.save(replica);
         return replica;

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/ReplicaService.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/ReplicaService.java
@@ -1,7 +1,7 @@
 package edu.umich.lib.dor.replicaexperiment.service;
 
-import java.util.List;
 import java.time.Instant;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -39,6 +39,9 @@ public class ReplicaService {
             .stream()
             .filter(r -> r.getRepository().getId() == repository.getId())
             .toList();
+        if (matchingReplicas.size() == 0) {
+            return null;
+        }
         return matchingReplicas.getFirst();
     }
 
@@ -49,5 +52,9 @@ public class ReplicaService {
         replica.setUpdatedAt(Instant.now());
         replicaRepo.save(replica);
         return replica;
+    }
+
+    public void deleteReplica(Replica replica) {
+        replicaRepo.delete(replica);
     }
 }

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Replication.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Replication.java
@@ -13,13 +13,12 @@ public class Replication implements Command {
     RepositoryClientRegistry repositoryClientRegistry;
     Path stagingPath;
     String packageIdentifier;
-    Repository sourceRepository;
-    RepositoryClient sourceRepositoryClient;
-    String targetRepositoryName;
-    Repository targetRepository;
-    RepositoryClient targetRepositoryClient;
 
     InfoPackage infoPackage;
+    Repository sourceRepository;
+    RepositoryClient sourceRepositoryClient;
+    Repository targetRepository;
+    RepositoryClient targetRepositoryClient;
 
     public Replication(
         InfoPackageService infoPackageService,
@@ -58,7 +57,8 @@ public class Replication implements Command {
             );
         }
         this.sourceRepositoryClient = repositoryClientRegistry.getClient(sourceRepositoryName);
-        if (!infoPackage.hasAReplicaIn(sourceRepositoryName)) {
+        var sourceReplica = replicaService.getReplica(infoPackage, sourceRepository);
+        if (sourceReplica == null) {
             throw new NoEntityException(
                 String.format(
                     "No replica for package \"%s\" was found in repository \"%s\".",
@@ -68,7 +68,6 @@ public class Replication implements Command {
             );
         }
 
-        this.targetRepositoryName = targetRepositoryName;
         this.targetRepository = repositoryService.getRepository(targetRepositoryName);
         if (targetRepository == null) {
             throw new NoEntityException(
@@ -86,7 +85,6 @@ public class Replication implements Command {
         sourceRepositoryClient.exportObject(packageIdentifier, objectPathInStaging);
         targetRepositoryClient.importObject(objectPathInStaging);
 
-        targetRepository = repositoryService.getRepository(targetRepositoryName);
         replicaService.createReplica(infoPackage, targetRepository);
     }
 }

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Replication.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Replication.java
@@ -3,6 +3,7 @@ package edu.umich.lib.dor.replicaexperiment.service;
 import java.nio.file.Path;
 
 import edu.umich.lib.dor.replicaexperiment.domain.InfoPackage;
+import edu.umich.lib.dor.replicaexperiment.domain.Replica;
 import edu.umich.lib.dor.replicaexperiment.domain.Repository;
 import edu.umich.lib.dor.replicaexperiment.exception.NoEntityException;
 
@@ -57,7 +58,7 @@ public class Replication implements Command {
             );
         }
         this.sourceRepositoryClient = repositoryClientRegistry.getClient(sourceRepositoryName);
-        var sourceReplica = replicaService.getReplica(infoPackage, sourceRepository);
+        Replica sourceReplica = replicaService.getReplica(infoPackage, sourceRepository);
         if (sourceReplica == null) {
             throw new NoEntityException(
                 String.format(

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/RepositoryClient.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/RepositoryClient.java
@@ -10,11 +10,13 @@ public interface RepositoryClient {
 
     RepositoryClient readObject(String id, Path outputPath);
 
-    RepositoryClient deleteObject(String id);
+    RepositoryClient purgeObject(String id);
 
     boolean hasObject(String id);
 
-    RepositoryClient deleteObjectFile(String objectId, String filePath, Curator curator, String message);
+    RepositoryClient deleteObjectFile(
+        String objectId, String filePath, Curator curator, String message
+    );
 
     RepositoryClient updateObjectFiles(
         String objectId, Package sourcePackage, Curator curator, String message

--- a/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
+++ b/src/main/java/edu/umich/lib/dor/replicaexperiment/service/Update.java
@@ -1,10 +1,10 @@
 package edu.umich.lib.dor.replicaexperiment.service;
 
 import java.nio.file.Path;
-import java.util.List;
 
 import edu.umich.lib.dor.replicaexperiment.domain.Curator;
 import edu.umich.lib.dor.replicaexperiment.domain.InfoPackage;
+import edu.umich.lib.dor.replicaexperiment.domain.Replica;
 import edu.umich.lib.dor.replicaexperiment.domain.Repository;
 import edu.umich.lib.dor.replicaexperiment.exception.NoEntityException;
 
@@ -24,8 +24,7 @@ public class Update implements Command {
     Repository repository;
     RepositoryClient repositoryClient;
     Package sourcePackage;
-    Path updatePackagePath;
-    List<Path> updateFilePaths;
+    Replica replica;
 
     public Update(
         InfoPackageService infoPackageService,
@@ -70,7 +69,8 @@ public class Update implements Command {
             );
         }
         this.repositoryClient = repositoryClientRegistry.getClient(repositoryName);
-        if (!existingPackage.hasAReplicaIn(repositoryName)) {
+        this.replica = replicaService.getReplica(existingPackage, repository);
+        if (replica == null) {
             throw new NoEntityException(
                 String.format(
                     "No replica for package \"%s\" was found in repository \"%s\".",
@@ -90,6 +90,6 @@ public class Update implements Command {
             curator,
             message
         );
-        replicaService.updateReplica(existingPackage, repository);
+        replicaService.updateReplica(replica);
     }
 }

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/OcflFilesystemRepositoryClientTest.java
@@ -164,4 +164,10 @@ public class OcflFilesystemRepositoryClientTest {
             Paths.get("some/path/staging/A"), OcflOption.MOVE_SOURCE
         );
     }
+
+    @Test
+    public void clientPurgesObject() {
+        repositoryClient.purgeObject("A");
+        verify(ocflRepositoryMock).purgeObject("A");
+    }
 }

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/PurgeTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/PurgeTest.java
@@ -1,6 +1,6 @@
 package edu.umich.lib.dor.replicaexperiment;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,10 +66,10 @@ public class PurgeTest {
 
     @Test
     void purgeFailsWhenInfoPackageDoesNotExist() {
-        when(packageServiceMock.getInfoPackage("A")).thenReturn(null);
+        when(packageServiceMock.getInfoPackage("?")).thenReturn(null);
     
         assertThrows(NoEntityException.class, () -> {
-            purgeFactory.create("A", "some_repo");
+            purgeFactory.create("?", "some_repo");
         });
     }
 
@@ -85,12 +85,11 @@ public class PurgeTest {
 
     @Test
     void purgeFailsWhenInfoPackageDoesNotHaveReplicaInRepository() {
-        Repository sourceRepositoryMock = mock(Repository.class);
-
         when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
-        when(repositoryServiceMock.getRepository("some_repo")).thenReturn(sourceRepositoryMock);
+        when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
         when(registryMock.getClient("some_repo")).thenReturn(clientMock);
-        when(infoPackageMock.hasAReplicaIn("some_repo")).thenReturn(false);
+        when(replicaServiceMock.getReplica(infoPackageMock, repositoryMock))
+            .thenReturn(null);
 
         assertThrows(NoEntityException.class, () -> {
             purgeFactory.create("A", "some_repo");

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/PurgeTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/PurgeTest.java
@@ -1,0 +1,114 @@
+package edu.umich.lib.dor.replicaexperiment;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import edu.umich.lib.dor.replicaexperiment.domain.InfoPackage;
+import edu.umich.lib.dor.replicaexperiment.domain.Replica;
+import edu.umich.lib.dor.replicaexperiment.domain.Repository;
+import edu.umich.lib.dor.replicaexperiment.exception.NoEntityException;
+import edu.umich.lib.dor.replicaexperiment.service.InfoPackageService;
+import edu.umich.lib.dor.replicaexperiment.service.Purge;
+import edu.umich.lib.dor.replicaexperiment.service.PurgeFactory;
+import edu.umich.lib.dor.replicaexperiment.service.ReplicaService;
+import edu.umich.lib.dor.replicaexperiment.service.RepositoryClient;
+import edu.umich.lib.dor.replicaexperiment.service.RepositoryClientRegistry;
+import edu.umich.lib.dor.replicaexperiment.service.RepositoryService;
+
+public class PurgeTest {
+    InfoPackageService packageServiceMock;
+    RepositoryService repositoryServiceMock;
+    ReplicaService replicaServiceMock;
+    RepositoryClientRegistry registryMock;
+
+    InfoPackage infoPackageMock;
+    RepositoryClient clientMock;
+    Replica replicaMock;
+    Repository repositoryMock;
+
+    PurgeFactory purgeFactory;
+
+    @BeforeEach
+    void init() {
+        this.packageServiceMock = mock(InfoPackageService.class);
+        this.repositoryServiceMock = mock(RepositoryService.class);
+        this.replicaServiceMock = mock(ReplicaService.class);
+        this.registryMock = mock(RepositoryClientRegistry.class);
+
+        this.infoPackageMock = mock(InfoPackage.class);
+        this.clientMock = mock(RepositoryClient.class);
+        this.replicaMock = mock(Replica.class);
+        this.repositoryMock = mock(Repository.class);
+
+        this.purgeFactory = new PurgeFactory(
+            packageServiceMock,
+            repositoryServiceMock,
+            replicaServiceMock,
+            registryMock
+        );
+    }
+
+    @Test
+    void factoryCreatesPurge() {
+        when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
+        when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
+        when(registryMock.getClient("some_repo")).thenReturn(clientMock);
+        when(replicaServiceMock.getReplica(infoPackageMock, repositoryMock))
+            .thenReturn(replicaMock);
+
+        purgeFactory.create("A", "some_repo");
+    }
+
+    @Test
+    void purgeFailsWhenInfoPackageDoesNotExist() {
+        when(packageServiceMock.getInfoPackage("A")).thenReturn(null);
+    
+        assertThrows(NoEntityException.class, () -> {
+            purgeFactory.create("A", "some_repo");
+        });
+    }
+
+    @Test
+    void purgeFailsWhenSourceRepositoryDoesNotExist() {
+        when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
+        when(repositoryServiceMock.getRepository("some_imaginary_repo")).thenReturn(null);
+
+        assertThrows(NoEntityException.class, () -> {
+            purgeFactory.create("A", "some_imaginary_repo");
+        });
+    }
+
+    @Test
+    void purgeFailsWhenInfoPackageDoesNotHaveReplicaInRepository() {
+        Repository sourceRepositoryMock = mock(Repository.class);
+
+        when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
+        when(repositoryServiceMock.getRepository("some_repo")).thenReturn(sourceRepositoryMock);
+        when(registryMock.getClient("some_repo")).thenReturn(clientMock);
+        when(infoPackageMock.hasAReplicaIn("some_repo")).thenReturn(false);
+
+        assertThrows(NoEntityException.class, () -> {
+            purgeFactory.create("A", "some_repo");
+        });
+    }
+
+    @Test
+    void purgeExecutes() {
+        when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
+        when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
+        when(registryMock.getClient("some_repo")).thenReturn(clientMock);
+        when(replicaServiceMock.getReplica(infoPackageMock, repositoryMock))
+            .thenReturn(replicaMock);
+
+        Purge purge = purgeFactory.create("A", "some_repo");
+
+        purge.execute();
+        verify(clientMock).purgeObject("A");
+        verify(replicaServiceMock).deleteReplica(replicaMock);
+    }
+}

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/ReplicationTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/ReplicationTest.java
@@ -73,7 +73,8 @@ public class ReplicationTest {
         when(repositoryServiceMock.getRepository("some_repo")).thenReturn(sourceRepositoryMock);
         when(registryMock.getClient("some_repo")).thenReturn(sourceClientMock);
         when(infoPackageMock.hasAReplicaIn("some_repo")).thenReturn(true);
-        when(repositoryServiceMock.getRepository("some_other_repo")).thenReturn(targetRepositoryMock);
+        when(repositoryServiceMock.getRepository("some_other_repo"))
+            .thenReturn(targetRepositoryMock);
         when(registryMock.getClient("some_other_repo")).thenReturn(targetClientMock);
 
         assertDoesNotThrow(() -> {

--- a/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
+++ b/src/test/java/edu/umich/lib/dor/replicaexperiment/UpdateTest.java
@@ -5,9 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +42,6 @@ public class UpdateTest {
     OcflFilesystemRepositoryClient clientMock;
     Package sourcePackageMock;
 
-
     @BeforeEach
     void init() {
         this.packageServiceMock = mock(InfoPackageService.class);
@@ -72,7 +69,8 @@ public class UpdateTest {
     void updateCanBeCreated() {
         when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
         when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
-        when(infoPackageMock.hasAReplicaIn("some_repo")).thenReturn(true);
+        when(replicaServiceMock.getReplica(infoPackageMock, repositoryMock))
+            .thenReturn(replicaMock);
 
         when(registryMock.getClient("some_repo")).thenReturn(clientMock);
         when(depositDirMock.getPackage(Paths.get("update_A"))).thenReturn(sourcePackageMock);
@@ -108,7 +106,8 @@ public class UpdateTest {
         when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
         when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
         when(registryMock.getClient("some_repo")).thenReturn(clientMock);
-        when(infoPackageMock.hasAReplicaIn("some_repo")).thenReturn(false);
+        when(replicaServiceMock.getReplica(infoPackageMock, repositoryMock))
+            .thenReturn(null);
 
         assertThrows(NoEntityException.class, () -> {
             updateFactory.create(
@@ -126,12 +125,8 @@ public class UpdateTest {
         when(packageServiceMock.getInfoPackage("A")).thenReturn(infoPackageMock);
         when(repositoryServiceMock.getRepository("some_repo")).thenReturn(repositoryMock);
         when(registryMock.getClient("some_repo")).thenReturn(clientMock);
-        when(infoPackageMock.hasAReplicaIn("some_repo")).thenReturn(true);
-
-        List<Path> newPackagePaths = List.of(
-            Paths.get("something.txt"),
-            Paths.get("something_new.txt")
-        );
+        when(replicaServiceMock.getReplica(infoPackageMock, repositoryMock))
+            .thenReturn(replicaMock);
 
         when(depositDirMock.getPackage(Paths.get("update_A"))).thenReturn(sourcePackageMock);
 
@@ -150,6 +145,6 @@ public class UpdateTest {
             testCurator,
             "we're good"
         );
-        verify(replicaServiceMock).updateReplica(infoPackageMock, repositoryMock);
+        verify(replicaServiceMock).updateReplica(replicaMock);
     }
 }


### PR DESCRIPTION
Resolves #19.

- [x] Add `deleteReplica` to `ReplicaService`, change `getReplica` to return `null` when not found
- [x] Create `PurgeFactory`/`Purge` `Command`, with tests
- [x] Refactor `ReplicaService.updateReplica` to take a `Replica`
- [x] Refactor `Update` and `Replication` to use `ReplicaService.getReplica` over `InfoPackage.hasAReplicaIn`.
- [x] Remove some unused code leftover from previous PR (#16) ☹️ 